### PR TITLE
chore: migrate to pnpm 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "resend-nodemailer-smtp-example",
   "private": true,
+  "packageManager": "pnpm@11.3.0",
   "scripts": {
     "dev": "bun index.ts",
     "lint": "biome check .",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+minimumReleaseAge: 1440

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,3 @@
-minimumReleaseAge: 1440
 allowBuilds:
   "@biomejs/biome": true
   bun: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,1 +1,4 @@
 minimumReleaseAge: 1440
+allowBuilds:
+  "@biomejs/biome": true
+  bun: true


### PR DESCRIPTION
Bumps `packageManager` to pnpm@11.3.0 and approves dependency build scripts via `allowBuilds` (`@biomejs/biome`, `bun`) so pnpm 11 doesn't fail CI on ignored build scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)